### PR TITLE
chore: v0.5.2, compatible range to NodeCG 1.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lfg-siphon",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "dependencies": {
     "clone": "^2.1.0",
     "deep-equal": "^1.0.1",
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": "https://lange@github.com/SupportClass/lfg-siphon.git",
   "nodecg": {
-    "compatibleRange": "~0.9.0",
+    "compatibleRange": "^1.0.0",
     "graphics": []
   },
   "devDependencies": {


### PR DESCRIPTION
NodeCG Range and version bump intended to address production issue.

No real changes to this project, its a dependency of other things and needs the version changed to match.